### PR TITLE
Quick fix for ECP

### DIFF
--- a/python/common_utils.py
+++ b/python/common_utils.py
@@ -350,6 +350,7 @@ def cell(args):
     c.exp_to_discard = args.diffuse_cutoff
     if np.linalg.det(_a) < 0:
         raise "Lattice are not in right-handed coordinate system. Please correct your lattice vectors"
+    c.build()
     return c
 
 


### PR DESCRIPTION
The missing `cell.build()` call was causing lots of issues with ECP that were extremely difficult to catch. For example, the generated auxiliary ETB basis set was wrong for ECP atoms. There were issues with integrals as well.