### PR TITLE
remove Green's function update from "diff" function in Dyson.

### DIFF
--- a/src/dyson.cpp
+++ b/src/dyson.cpp
@@ -290,7 +290,6 @@ namespace green::mbpt {
   template <>
   double dyson<utils::shared_object<ztensor<5>>, ztensor<4>, utils::shared_object<ztensor<5>>>::diff(G& g, Sigma1& sigma1,
                                                                                                      Sigma_tau& sigma_tau) {
-    compute_G(g, sigma1, sigma_tau);
     auto [e1, e2, e3] = compute_energy(g.object(), sigma1, sigma_tau.object(), _H_k, _ft, _bz_utils, _nao != _nso);
     double diff       = std::abs(_E_1b - e1) + std::abs(_E_hf - e2) + std::abs(_E_corr - e3);
     _E_1b             = e1;
@@ -301,7 +300,6 @@ namespace green::mbpt {
 
   template <>
   double dyson<ztensor<5>, ztensor<4>, ztensor<5>>::diff(G& g, Sigma1& sigma1, Sigma_tau& sigma_tau) {
-    compute_G(g, sigma1, sigma_tau);
     auto [e1, e2, e3] = compute_energy(g, sigma1, sigma_tau, _H_k, _ft, _bz_utils, _nao != _nso);
     double diff       = std::abs(_E_1b - e1) + std::abs(_E_hf - e2) + std::abs(_E_corr - e3);
     _E_1b             = e1;


### PR DESCRIPTION
The `compute_G` calls were creating new Green's function (stored in `g`) without updating chemical potential, leading to incorrect densities and particle number.

This updated `g` with incorrect electron number is then stored in the output file (within [green-sc](https://github.com/green-phys/green-sc)) which is problematic in diagnosing properties when we are unable to achieve self-consistency.