### PR TITLE
check if results_file exists before running winter job.

### DIFF
--- a/src/green/mbpt/except.h
+++ b/src/green/mbpt/except.h
@@ -44,5 +44,11 @@ namespace green::mbpt {
   public:
     explicit mbpt_outdated_input(const std::string& what) : std::runtime_error(what) {}
   };
+
+  class mbpt_wrong_results_file : public std::runtime_error {
+  public:
+    explicit mbpt_wrong_results_file(const std::string& what) : std::runtime_error(what) {}
+  };
+
 }  // namespace green::mbpt
 #endif  // GREEN_MBPT_EXCEPT_H

--- a/src/green/mbpt/mbpt_run.h
+++ b/src/green/mbpt/mbpt_run.h
@@ -24,12 +24,14 @@
 
 #include <green/params/params.h>
 #include <green/sc/sc_loop.h>
+#include <filesystem>
 
 #include "common_defs.h"
 #include "dyson.h"
 #include "gf2_solver.h"
 #include "gw_solver.h"
 #include "hf_solver.h"
+#include "except.h"
 
 namespace green::mbpt {
 
@@ -223,9 +225,14 @@ namespace green::mbpt {
                          utils::shared_object<ztensor<5>>& g0_tau, utils::shared_object<ztensor<5>>& sigma_tau,
                          ztensor<4>& sigma1) {
     h5pp::archive input(p["input_file"]);
+    std::string results_file = p["results_file"].as<std::string>();
+    if (!std::filesystem::exists(results_file)) {
+      throw mbpt_wrong_results_file("Results file '" + results_file + "' does not exist. " +
+                                    "Please verify the path is correct, or run the 'SC' job before running 'WINTER'.");
+    }
     if (input.has_group("high_symm_path")) {
       if (!utils::context.global_rank) std::cout << "Running Wannier interpolation" << std::endl;
-      sc::read_results(dyson.mu(), g0_tau, sigma1, sigma_tau, p["results_file"]);
+      sc::read_results(dyson.mu(), g0_tau, sigma1, sigma_tau, results_file);
       wannier_interpolation(dyson, sigma1, sigma_tau, input, p["high_symmetry_output_file"]);
     }
     input.close();


### PR DESCRIPTION
Fixes Issue #23 
Previously, Winter job starts in a "restart"-style, in which the function `sc::read_results` looks for `results_file` to read `signa_inf` and `sigma_tau`. But if the file does not exist, it safely initializes the self-energies to 0. This is why the WINTER job never crashed even in the absence of `results_file`.

Future TODO: need to add testing for K-point interpolation functionality.