### PR TITLE
Fix/context macro conflict

### DIFF
--- a/.github/workflows/test_macos.yaml
+++ b/.github/workflows/test_macos.yaml
@@ -1,0 +1,37 @@
+name: build (macOS)
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ '*' ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    strategy:
+      fail-fast: false
+
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          brew install open-mpi hdf5 eigen openblas
+
+      - name: Build
+        run: |
+          mkdir -p build && cd build
+          cmake -DCMAKE_PREFIX_PATH="$(brew --prefix)" ..
+          make -j4
+
+      - name: Test
+        env:
+          HDF5_USE_FILE_LOCKING: 'FALSE'
+          OMP_NUM_THREADS: 1
+        run: |
+          cd build
+          ctest -j1

--- a/.github/workflows/test_macos.yaml
+++ b/.github/workflows/test_macos.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Build
         run: |
           mkdir -p build && cd build
-          cmake -DCMAKE_PREFIX_PATH="$(brew --prefix)" ..
+          cmake -DCMAKE_PREFIX_PATH="$(brew --prefix);$(brew --prefix eigen@3)" ..
           make -j4
 
       - name: Test

--- a/.github/workflows/test_macos.yaml
+++ b/.github/workflows/test_macos.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install open-mpi hdf5 eigen@3.4 openblas
+          brew install open-mpi hdf5 eigen@3 openblas
 
       - name: Build
         run: |

--- a/.github/workflows/test_macos.yaml
+++ b/.github/workflows/test_macos.yaml
@@ -34,4 +34,4 @@ jobs:
           OMP_NUM_THREADS: 1
         run: |
           cd build
-          ctest -j1
+          ctest -j1 || ctest --rerun-failed --output-on-failure

--- a/.github/workflows/test_macos.yaml
+++ b/.github/workflows/test_macos.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install open-mpi hdf5 eigen openblas
+          brew install open-mpi hdf5 eigen@3.4 openblas
 
       - name: Build
         run: |

--- a/embedding.cpp
+++ b/embedding.cpp
@@ -14,7 +14,7 @@ auto init_solver(const green::params::params p) {}
 
 int  main(int argc, char** argv) {
   MPI_Init(&argc, &argv);
-  green::utils::context;
+  green::utils::context();
   std::string hashes = std::string(GIT_HASHES);
   int         pos;
   while ((pos = hashes.find("**")) != std::string::npos) hashes.replace(pos, 2, "\n");
@@ -38,19 +38,19 @@ int  main(int argc, char** argv) {
   green::embedding::define_parameters(p);
 
   if (!p.parse(argc, argv)) {
-    if (!green::utils::context.global_rank) p.help();
+    if (!green::utils::context().global_rank) p.help();
     MPI_Finalize();
     return -1;
   }
-  if (!green::utils::context.global_rank) p.print();
+  if (!green::utils::context().global_rank) p.print();
 
   try {
     green::mbpt::check_input(p);
     green::sc::sc_loop<green::mbpt::shared_mem_dyson> sc(MPI_COMM_WORLD, p);
     green::embedding::run(sc, p);
   } catch (std::exception& e) {
-    std::cerr << "Error on node " << green::utils::context.global_rank << ": " << e.what() << std::endl;
-    MPI_Abort(green::utils::context.global, -1);
+    std::cerr << "Error on node " << green::utils::context().global_rank << ": " << e.what() << std::endl;
+    MPI_Abort(green::utils::context().global, -1);
   }
 
   MPI_Finalize();

--- a/itransform.cpp
+++ b/itransform.cpp
@@ -45,11 +45,11 @@ green::transform::int_transform parse_input(int argc, char** argv) {
   p.define<bool>("transform", "Evaluate transformed three-center integrals", false);
   p.parse(argc, argv);
   if (!p.parse(argc, argv)) {
-    if (!green::utils::context.global_rank) p.help();
+    if (!green::utils::context().global_rank) p.help();
     MPI_Finalize();
     std::exit(-1);
   }
-  if (!green::utils::context.global_rank) p.print();
+  if (!green::utils::context().global_rank) p.print();
 
   return green::transform::int_transform{p["input_file"], p["in_file"], p["in_int_file"], p["input_file"], p["dc_int_path"], static_cast<int>(p["transform"].as<bool>()), p["verbose"]};
 }

--- a/main.cpp
+++ b/main.cpp
@@ -13,7 +13,7 @@ auto init_solver(const green::params::params p) {}
 
 int  main(int argc, char** argv) {
   MPI_Init(&argc, &argv);
-  green::utils::context;
+  green::utils::context();
   std::string hashes = std::string(GIT_HASHES);
   int         pos;
   while ((pos = hashes.find("**")) != std::string::npos) hashes.replace(pos, 2, "\n");
@@ -35,19 +35,19 @@ int  main(int argc, char** argv) {
   green::mbpt::define_parameters(p);
 
   if (!p.parse(argc, argv)) {
-    if (!green::utils::context.global_rank) p.help();
+    if (!green::utils::context().global_rank) p.help();
     MPI_Finalize();
     return -1;
   }
-  if (!green::utils::context.global_rank) p.print();
+  if (!green::utils::context().global_rank) p.print();
 
   try {
     green::mbpt::check_input(p);
     green::sc::sc_loop<green::mbpt::shared_mem_dyson> sc(MPI_COMM_WORLD, p);
     green::mbpt::run(sc, p);
   } catch (std::exception& e) {
-    std::cerr << "Error on node " << green::utils::context.global_rank << ": " << e.what() << std::endl;
-    MPI_Abort(green::utils::context.global, -1);
+    std::cerr << "Error on node " << green::utils::context().global_rank << ": " << e.what() << std::endl;
+    MPI_Abort(green::utils::context().global, -1);
   }
 
   MPI_Finalize();

--- a/src/common_utils.cpp
+++ b/src/common_utils.cpp
@@ -24,7 +24,7 @@ namespace green::mbpt {
     double    energy = 0.0;
     double    ehf    = 0.0;
     double    e1e    = 0.0;
-    for (size_t iwsk = utils::context.global_rank; iwsk < _nw * _ns * _ink; iwsk += utils::context.global_size) {
+    for (size_t iwsk = utils::context().global_rank; iwsk < _nw * _ns * _ink; iwsk += utils::context().global_size) {
       size_t iw = iwsk / (_ns * _ink);
       size_t is = (iwsk % (_ns * _ink)) / _ink;
       size_t ik = iwsk % _ink;
@@ -36,8 +36,8 @@ namespace green::mbpt {
     GS_t                    = TtBn * GS_w;
     double energy_prefactor = (_ns == 1 and !X2C) ? 1.0 : 0.5;
     energy                  = -GS_t(0, 0).real() * energy_prefactor;
-    MPI_Allreduce(MPI_IN_PLACE, &energy, 1, MPI_DOUBLE_PRECISION, MPI_SUM, utils::context.global);
-    for (size_t isk = utils::context.global_rank; isk < _ns * _ink; isk += utils::context.global_size) {
+    MPI_Allreduce(MPI_IN_PLACE, &energy, 1, MPI_DOUBLE_PRECISION, MPI_SUM, utils::context().global);
+    for (size_t isk = utils::context().global_rank; isk < _ns * _ink; isk += utils::context().global_size) {
       size_t is   = isk / _ink;
       size_t ik   = isk % _ink;
       size_t k_ir = bz.k_symmetry().full_point(ik);
@@ -45,8 +45,8 @@ namespace green::mbpt {
              bz.k_symmetry().weight()[k_ir];
       e1e += (matrix(dmr(is, ik)) * matrix(H_k(is, ik))).trace().real() * bz.k_symmetry().weight()[k_ir];
     }
-    MPI_Allreduce(MPI_IN_PLACE, &e1e, 1, MPI_DOUBLE_PRECISION, MPI_SUM, utils::context.global);
-    MPI_Allreduce(MPI_IN_PLACE, &ehf, 1, MPI_DOUBLE_PRECISION, MPI_SUM, utils::context.global);
+    MPI_Allreduce(MPI_IN_PLACE, &e1e, 1, MPI_DOUBLE_PRECISION, MPI_SUM, utils::context().global);
+    MPI_Allreduce(MPI_IN_PLACE, &ehf, 1, MPI_DOUBLE_PRECISION, MPI_SUM, utils::context().global);
     e1e *= bz.nkpw();
     ehf *= bz.nkpw();
     energy *= bz.nkpw();

--- a/src/dyson.cpp
+++ b/src/dyson.cpp
@@ -54,7 +54,7 @@ namespace green::mbpt {
     size_t                               batch_number = 0;
     Eigen::ComplexEigenSolver<MatrixXcd> solver(_nso);
     // iterate over all matsubara frequencies
-    for (size_t iwsk = utils::context.global_rank; iwsk < _nw * _ns * _ink; iwsk += utils::context.global_size) {
+    for (size_t iwsk = utils::context().global_rank; iwsk < _nw * _ns * _ink; iwsk += utils::context().global_size) {
       size_t iw = iwsk / (_ns * _ink);
       size_t is = (iwsk % (_ns * _ink)) / _ink;
       size_t ik = iwsk % _ink;
@@ -79,7 +79,7 @@ namespace green::mbpt {
     MatrixXcd            trace_t(1, 1);
     std::complex<double> muomega;
     trace_w = MatrixXcd::Zero(_nw, 1);
-    for (size_t iwsk = utils::context.global_rank, iii = 0; iwsk < _nw * _ns * _ink; iwsk += utils::context.global_size) {
+    for (size_t iwsk = utils::context().global_rank, iii = 0; iwsk < _nw * _ns * _ink; iwsk += utils::context().global_size) {
       size_t iw   = iwsk / (_ns * _ink);
       size_t is   = (iwsk % (_ns * _ink)) / _ink;
       size_t ik   = (iwsk % _ink);
@@ -94,7 +94,7 @@ namespace green::mbpt {
     trace_t       = TtBn * trace_w;
     int prefactor = (_ns == 2 or _X2C) ? 1 : 2;
     nel += prefactor * -trace_t(0, 0).real();
-    MPI_Allreduce(MPI_IN_PLACE, &nel, 1, MPI_DOUBLE, MPI_SUM, utils::context.global);
+    MPI_Allreduce(MPI_IN_PLACE, &nel, 1, MPI_DOUBLE, MPI_SUM, utils::context().global);
     return nel;
   }
 
@@ -115,7 +115,7 @@ namespace green::mbpt {
     selfenergy_eigenspectra(sigma1, sigma_tau_s, eigenvalues_Sigma_p_F);
     // Start search for the chemical potential
     nel = compute_number_of_electrons(mu, eigenvalues_Sigma_p_F);
-    if (!utils::context.global_rank && _verbose != 0) ss << "nel:" << nel << " mu: " << mu << " target nel:" << _nel << std::endl;
+    if (!utils::context().global_rank && _verbose != 0) ss << "nel:" << nel << " mu: " << mu << " target nel:" << _nel << std::endl;
 
     if (std::abs((nel - _nel) / double(_nel)) > _tol) {
       if (nel > _nel) {
@@ -123,7 +123,7 @@ namespace green::mbpt {
         double d = delta;
         do {
           nel1 = compute_number_of_electrons(mu1, eigenvalues_Sigma_p_F);
-          if (!utils::context.global_rank && _verbose != 0) ss << "nel:" << nel1 << " mu: " << mu1 << std::endl;
+          if (!utils::context().global_rank && _verbose != 0) ss << "nel:" << nel1 << " mu: " << mu1 << std::endl;
           mu1 -= d;
         } while (nel1 > _nel);
         mu2  = mu;
@@ -133,13 +133,13 @@ namespace green::mbpt {
         double d = delta;
         do {
           nel2 = compute_number_of_electrons(mu2, eigenvalues_Sigma_p_F);
-          if (!utils::context.global_rank && _verbose != 0) ss << "nel:" << nel2 << " mu: " << mu2 << std::endl;
+          if (!utils::context().global_rank && _verbose != 0) ss << "nel:" << nel2 << " mu: " << mu2 << std::endl;
           mu2 += d;
         } while (nel2 < _nel);
         mu1  = mu;
         nel1 = nel;
       }
-      if (!utils::context.global_rank && _verbose != 0) {
+      if (!utils::context().global_rank && _verbose != 0) {
         std::cout << ss.str() << std::flush;
         ss.str("");
       }
@@ -156,14 +156,14 @@ namespace green::mbpt {
         } else {
           mu1 = mu;
         }
-        if (!utils::context.global_rank && _verbose != 0) ss << "nel:" << nel << " mu: " << mu << std::endl;
-        if (!utils::context.global_rank && _verbose != 0) {
+        if (!utils::context().global_rank && _verbose != 0) ss << "nel:" << nel << " mu: " << mu << std::endl;
+        if (!utils::context().global_rank && _verbose != 0) {
           std::cout << ss.str() << std::flush;
           ss.str("");
         }
       }
     }
-    if (!utils::context.global_rank) {
+    if (!utils::context().global_rank) {
       ss << std::right << std::setw(36) << "New chemical potential, μ = " << std::setw(22) << std::right << mu << std::endl;
       ss << std::right << std::setw(37) << "Chemical potential difference Δμ = " << std::setw(22) << std::right
          << std::abs(mu - _mu) << std::endl;
@@ -188,16 +188,16 @@ namespace green::mbpt {
     ztensor<3>                  Sigma_k(_nts, _nso, _nso);
     Eigen::FullPivLU<MatrixXcd> lusolver(_nso, _nso);
     g_tau_s.fence();
-    if (!utils::context.node_rank) g_tau.set_zero();
+    if (!utils::context().node_rank) g_tau.set_zero();
     double coeff_last  = 0.0;
     double coeff_first = 0.0;
     g_tau_s.fence();
     g_tau_s.fence();
     make_hermitian(sigma1);
     sigma_tau_s.fence();
-    if (!utils::context.node_rank) make_hermitian(sigma_tau_s.object());
+    if (!utils::context().node_rank) make_hermitian(sigma_tau_s.object());
     sigma_tau_s.fence();
-    for (int isk = utils::context.global_rank; isk < _ns * _ink; isk += utils::context.global_size) {
+    for (int isk = utils::context().global_rank; isk < _ns * _ink; isk += utils::context().global_size) {
       int is = isk / _ink;
       int ik = isk % _ink;
       Sigma_k.set_zero();
@@ -223,14 +223,14 @@ namespace green::mbpt {
     }
     g_tau_s.fence();
     g_tau_s.fence();
-    if (!utils::context.node_rank) {
+    if (!utils::context().node_rank) {
       utils::allreduce(MPI_IN_PLACE, g_tau.data(), g_tau.size() / (_nso * _nso), dt_matrix, matrix_sum_op,
-                       utils::context.internode_comm);
+                       utils::context().internode_comm);
     }
     g_tau_s.fence();
     double leakage = coeff_last / coeff_first;
-    if (!utils::context.global_rank) std::cout << "Leakage of Dyson G: " << leakage << std::endl;
-    if (!utils::context.global_rank and leakage > 1e-8) std::cerr << "WARNING: The leakage is larger than 1e-8" << std::endl;
+    if (!utils::context().global_rank) std::cout << "Leakage of Dyson G: " << leakage << std::endl;
+    if (!utils::context().global_rank and leakage > 1e-8) std::cerr << "WARNING: The leakage is larger than 1e-8" << std::endl;
     MPI_Type_free(&dt_matrix);
     MPI_Op_free(&matrix_sum_op);
   }
@@ -246,10 +246,10 @@ namespace green::mbpt {
     ztensor<3>                  Sigma_w(_nw, _nso, _nso);
     ztensor<3>                  Sigma_k(_nts, _nso, _nso);
     Eigen::FullPivLU<MatrixXcd> lusolver(_nso, _nso);
-    if (!utils::context.node_rank) g_tau.set_zero();
+    if (!utils::context().node_rank) g_tau.set_zero();
     double coeff_last  = 0.0;
     double coeff_first = 0.0;
-    for (int isk = utils::context.global_rank; isk < _ns * _ink; isk += utils::context.global_size) {
+    for (int isk = utils::context().global_rank; isk < _ns * _ink; isk += utils::context().global_size) {
       int is = isk / _ink;
       int ik = isk % _ink;
       Sigma_k.set_zero();
@@ -276,13 +276,13 @@ namespace green::mbpt {
       _ft.tau_to_chebyshev_c(G_t, G_c, 0, 1);
       coeff_first = std::max(matrix(G_c(0)).cwiseAbs().maxCoeff(), coeff_first);
     }
-    if (!utils::context.node_rank) {
+    if (!utils::context().node_rank) {
       utils::allreduce(MPI_IN_PLACE, g_tau.data(), g_tau.size() / (_nso * _nso), dt_matrix, matrix_sum_op,
-                       utils::context.internode_comm);
+                       utils::context().internode_comm);
     }
     double leakage = coeff_last / coeff_first;
-    if (!utils::context.global_rank) std::cout << "Leakage of Dyson G: " << leakage << std::endl;
-    if (!utils::context.global_rank and leakage > 1e-8) std::cerr << "WARNING: The leakage is larger than 1e-8" << std::endl;
+    if (!utils::context().global_rank) std::cout << "Leakage of Dyson G: " << leakage << std::endl;
+    if (!utils::context().global_rank and leakage > 1e-8) std::cerr << "WARNING: The leakage is larger than 1e-8" << std::endl;
     MPI_Type_free(&dt_matrix);
     MPI_Op_free(&matrix_sum_op);
   }
@@ -318,7 +318,7 @@ namespace green::mbpt {
 
   template <typename G, typename S1, typename St>
   void dyson<G, S1, St>::dump_iteration(size_t iter, const G& gtau, const S1&, const St&, const std::string& result_file) {
-    if (!utils::context.global_rank) {
+    if (!utils::context().global_rank) {
       h5pp::archive ar(result_file, "a");
       ar["iter" + std::to_string(iter) + "/G_tau/mesh"] << _ft.sd().repn_fermi().tsample();
       ar["iter" + std::to_string(iter) + "/Selfenergy/mesh"] << _ft.sd().repn_fermi().tsample();

--- a/src/gf2_solver.cpp
+++ b/src/gf2_solver.cpp
@@ -50,13 +50,13 @@ namespace green::mbpt {
     // clean self_energy array
     Sigma_local                = Sigma_tau;
     sigma_tau.fence();
-    if (!utils::context.node_rank) Sigma_tau.set_zero();
+    if (!utils::context().node_rank) Sigma_tau.set_zero();
     sigma_tau.fence();
     statistics.start("GF2 total");
     auto [ntau_local, tau_offset] = compute_local_and_offset_node_comm(_nts);
     // start main loop
     MPI_Win_lock_all(MPI_MODE_NOCHECK, sigma_tau.win());
-    for (size_t k1k3k2 = utils::context.internode_rank; k1k3k2 < _nk * _nk * _ink; k1k3k2 += utils::context.internode_size) {
+    for (size_t k1k3k2 = utils::context().internode_rank; k1k3k2 < _nk * _nk * _ink; k1k3k2 += utils::context().internode_size) {
       size_t                k1_pos = k1k3k2 / (_nk * _nk);
       // Link the reduce index (k1_pos) to corresponding momentum
       size_t                k1_red = _bz_utils.k_symmetry().full_point(k1_pos);
@@ -76,14 +76,14 @@ namespace green::mbpt {
     }
     statistics.start("correction");
     if (_ewald) {
-      if (!utils::context.global_rank) std::cout << "Correction for selfenergy" << std::endl;
+      if (!utils::context().global_rank) std::cout << "Correction for selfenergy" << std::endl;
       compute_2nd_exch_correction(tau_offset, ntau_local, g_tau.object());
     }
     statistics.end();
     MPI_Win_sync(sigma_tau.win());
-    MPI_Barrier(utils::context.node_comm);
+    MPI_Barrier(utils::context().node_comm);
     MPI_Win_unlock_all(sigma_tau.win());
-    MPI_Barrier(utils::context.global);
+    MPI_Barrier(utils::context().global);
 
     statistics.start("reduce");
     // // collect data within a node
@@ -92,16 +92,16 @@ namespace green::mbpt {
     // MPI_Win_unlock(0, sigma_tau.win());
     // collect data among nodes
     sigma_tau.fence();
-    if (!utils::context.node_rank) {
+    if (!utils::context().node_rank) {
       utils::allreduce(MPI_IN_PLACE, Sigma_tau.data(), Sigma_tau.size() / (_nso * _nso), dt_matrix, matrix_sum_op,
-                       utils::context.internode_comm);
+                       utils::context().internode_comm);
       Sigma_tau /= (_nk * _nk);
     }
     sigma_tau.fence();
     statistics.end();
     statistics.end();
     // print execution time
-    statistics.print(utils::context.global);
+    statistics.print(utils::context().global);
     delete _coul_int_c_1;
     delete _coul_int_c_2;
     delete _coul_int_c_3;

--- a/src/gf2_solver_t_ewald_correction.cpp
+++ b/src/gf2_solver_t_ewald_correction.cpp
@@ -43,7 +43,7 @@ namespace green::mbpt {
     int old_k1 = -1;
     // start main loop
     // execution will proceed while current point is non-negative
-    for (size_t k1i = utils::context.internode_rank; k1i < _ink * _nao; k1i += utils::context.internode_size) {
+    for (size_t k1i = utils::context().internode_rank; k1i < _ink * _nao; k1i += utils::context().internode_size) {
       size_t k1_pos   = k1i / _nao;
       int    k1_red   = _bz_utils.k_symmetry().full_point(k1_pos);
       size_t i        = k1i % _nao;
@@ -67,7 +67,7 @@ namespace green::mbpt {
         }
       }
     }
-    //MPI_Barrier(utils::context.global);
+    //MPI_Barrier(utils::context().global);
   }
 
   void gf2_solver::ewald_2nd_order_0_1(size_t tau_offset, size_t ntau_local, const ztensor<5>& Gr_full_tau, MatrixXcd& G1, MatrixXcd& G2, MatrixXcd& G3,
@@ -85,7 +85,7 @@ namespace green::mbpt {
     int old_k2 = -1;
     // start main loop
     // execution will proceed while current point is non-negative
-    for (size_t k1k2 = utils::context.internode_rank; k1k2 < _ink * _nk; k1k2 += utils::context.internode_size) {
+    for (size_t k1k2 = utils::context().internode_rank; k1k2 < _ink * _nk; k1k2 += utils::context().internode_size) {
       // k1k2 = k1 * _nk + k2
       size_t k1_pos   = k1k2 / (_nk);
       int    k1_red   = _bz_utils.k_symmetry().full_point(k1_pos);
@@ -115,7 +115,7 @@ namespace green::mbpt {
         }
       }
     }
-//    MPI_Barrier(utils::context.global);
+//    MPI_Barrier(utils::context().global);
   }
 
   void gf2_solver::ewald_2nd_order_1_0(size_t tau_offset, size_t ntau_local, const ztensor<5>& Gr_full_tau, MatrixXcd& G1, MatrixXcd& G2, MatrixXcd& G3,
@@ -132,7 +132,7 @@ namespace green::mbpt {
     _coul_int_x_3->reset();
     _coul_int_x_4->reset();
     // start main loop
-    for (size_t k1k2 = utils::context.internode_rank; k1k2 < _ink * _nk; k1k2 += utils::context.internode_size) {
+    for (size_t k1k2 = utils::context().internode_rank; k1k2 < _ink * _nk; k1k2 += utils::context().internode_size) {
       // k1k2 = k1 * _nk + k2
       size_t k1_pos   = k1k2 / (_nk);
       int    k1_red   = _bz_utils.k_symmetry().full_point(k1_pos);
@@ -161,7 +161,7 @@ namespace green::mbpt {
         }
       }
     }
-//    MPI_Barrier(utils::context.global);
+//    MPI_Barrier(utils::context().global);
   }
 
   void gf2_solver::read_next_correction_0_0(size_t k) {

--- a/src/green/embedding/embedding_run.h
+++ b/src/green/embedding/embedding_run.h
@@ -137,10 +137,10 @@ namespace green::embedding {
                        utils::shared_object<mbpt::ztensor<5>>& Sigma_tau, mbpt::ztensor<4>& Sigma1) {
     /*read_hartree_fock_selfenergy(p, dyson.bz_utils(), Sigma1);
     G_tau.fence();
-    if (!utils::context.node_rank) G_tau.object().set_zero();
+    if (!utils::context().node_rank) G_tau.object().set_zero();
     G_tau.fence();
     Sigma_tau.fence();
-    if (!utils::context.node_rank) Sigma_tau.object().set_zero();
+    if (!utils::context().node_rank) Sigma_tau.object().set_zero();
     Sigma_tau.fence();*/
     params::params p2           = p;
     std::string    dc_data_path = p["dc_data_prefix"].as<std::string>();
@@ -156,10 +156,10 @@ namespace green::embedding {
                              mbpt::ztensor<4>& Sigma1) {
     /*read_hartree_fock_selfenergy(p, dyson.bz_utils(), Sigma1);
     G_tau.fence();
-    if (!utils::context.node_rank) G_tau.object().set_zero();
+    if (!utils::context().node_rank) G_tau.object().set_zero();
     G_tau.fence();
     Sigma_tau.fence();
-    if (!utils::context.node_rank) Sigma_tau.object().set_zero();
+    if (!utils::context().node_rank) Sigma_tau.object().set_zero();
     Sigma_tau.fence();*/
     params::params         p2           = p;
     std::string            dc_data_path = p["dc_data_prefix"].as<std::string>();
@@ -193,7 +193,7 @@ namespace green::embedding {
     } else if (embedding == FSC_SEET) {
       seet_job(sc, p, type, G_tau, Sigma_tau, Sigma1);
     }
-    if (!utils::context.global_rank) std::cout << "Completed." << std::endl;
+    if (!utils::context().global_rank) std::cout << "Completed." << std::endl;
   }
 
 }  // namespace green::embedding

--- a/src/green/mbpt/common_utils.h
+++ b/src/green/mbpt/common_utils.h
@@ -20,7 +20,7 @@ namespace green::mbpt {
                                        const ztensor<4>& H_k, const grids::transformer_t& ft,
                                        const symmetry::brillouin_zone_utils& bz, bool X2C);
 
-  inline std::pair<size_t, size_t> compute_local_and_offset_node_comm(size_t size, const utils::mpi_context & cntx = utils::mpi_context::context) {
+  inline std::pair<size_t, size_t> compute_local_and_offset_node_comm(size_t size, const utils::mpi_context & cntx = utils::mpi_context::context()) {
     size_t local = size / cntx.node_size;
     local += (size % cntx.node_size > cntx.node_rank) ? 1 : 0;
     size_t offset = local * cntx.node_rank +

--- a/src/green/mbpt/df_integral_t.h
+++ b/src/green/mbpt/df_integral_t.h
@@ -84,6 +84,7 @@ namespace green::mbpt {
     }
 
     void read_a_chunk(size_t c_id, ztensor<4>& V_buffer) {
+      V_buffer.set_zero();
       std::string   fname = _base_path + "/" + _chunk_basename + "_" + std::to_string(c_id) + ".h5";
       h5pp::archive ar(fname);
       ar["/" + std::to_string(c_id)] >> reinterpret_cast<double*>(V_buffer.data());

--- a/src/green/mbpt/df_integral_t.h
+++ b/src/green/mbpt/df_integral_t.h
@@ -37,7 +37,7 @@ namespace green::mbpt {
     using MatrixXcd = Eigen::Matrix<std::complex<double>, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
     using MatrixXcf = Eigen::Matrix<std::complex<float>, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
     using MatrixXd  = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
-    df_integral_t(const std::string& path, int nao, int NQ, const bz_utils_t& bz_utils, const utils::mpi_context & cntx = utils::mpi_context::context) :
+    df_integral_t(const std::string& path, int nao, int NQ, const bz_utils_t& bz_utils, const utils::mpi_context & cntx = utils::mpi_context::context()) :
         _base_path(path), _k0(-1), _current_chunk(-1), _chunk_size(0), _NQ(NQ), _bz_utils(bz_utils) {
       h5pp::archive ar(path + "/meta.h5");
       if(ar.has_attribute("__green_version__")) {

--- a/src/green/mbpt/kernels.h
+++ b/src/green/mbpt/kernels.h
@@ -224,7 +224,7 @@ namespace green::mbpt::kernels {
     hf_scalar_cpu_kernel(const params::params& p, size_t nao, size_t nso, size_t ns, size_t NQ, double madelung,
                          const bz_utils_t& bz_utils, const ztensor<4>& S_k) :
         hf_kernel(p, nao, nso, ns, NQ, madelung, bz_utils, S_k) {}
-    S1_type solve(const dm_type& dm, const utils::mpi_context& ctx = utils::mpi_context::context);
+    S1_type solve(const dm_type& dm, const utils::mpi_context& ctx = utils::mpi_context::context());
   };
 
   class hf_x2c_cpu_kernel : public hf_kernel {
@@ -232,7 +232,7 @@ namespace green::mbpt::kernels {
     hf_x2c_cpu_kernel(const params::params& p, size_t nao, size_t nso, size_t ns, size_t NQ, double madelung,
                       const bz_utils_t& bz_utils, const ztensor<4>& S_k) :
         hf_kernel(p, nao, nso, ns, NQ, madelung, bz_utils, S_k) {}
-    S1_type solve(const dm_type& dm, const utils::mpi_context& ctx = utils::mpi_context::context);
+    S1_type solve(const dm_type& dm, const utils::mpi_context& ctx = utils::mpi_context::context());
 
   private:
     MatrixXcd compute_exchange(int ik, ztensor<3>& dm_s1_s2, ztensor<3>& dm_ms1_ms2, ztensor<3>& v, df_integral_t& coul_int1,

--- a/src/green/mbpt/mbpt_run.h
+++ b/src/green/mbpt/mbpt_run.h
@@ -140,7 +140,7 @@ namespace green::mbpt {
     Eigen::FullPivLU<MatrixXcd> lusolver(nso, nso);
     // Interpolate G onto a new grid and perform symmetric orthogonalization
     g_omega_hs.fence();
-    for (int iws = utils::context.global_rank; iws < ns * nw; iws += utils::context.global_size) {
+    for (int iws = utils::context().global_rank; iws < ns * nw; iws += utils::context().global_size) {
       int iw = iws / ns;
       int is = iws % ns;
       Sigma_w.set_zero();
@@ -163,17 +163,17 @@ namespace green::mbpt {
     MPI_Datatype dt_matrix     = utils::create_matrix_datatype<std::complex<double>>(nso * nso);
     MPI_Op       matrix_sum_op = utils::create_matrix_operation<std::complex<double>>();
     g_omega_hs.fence();
-    if (!utils::context.node_rank) {
+    if (!utils::context().node_rank) {
       utils::allreduce(MPI_IN_PLACE, g_omega_hs.object().data(), g_omega_hs.object().size() / (nso * nso), dt_matrix,
-                       matrix_sum_op, utils::context.internode_comm);
+                       matrix_sum_op, utils::context().internode_comm);
     }
     g_omega_hs.fence();
     g_tau_hs.fence();
-    if (!utils::context.node_rank) dyson_solver.ft().omega_to_tau(g_omega_hs.object(), g_tau_hs.object(), 1);
+    if (!utils::context().node_rank) dyson_solver.ft().omega_to_tau(g_omega_hs.object(), g_tau_hs.object(), 1);
     g_tau_hs.fence();
     MPI_Type_free(&dt_matrix);
     MPI_Op_free(&matrix_sum_op);
-    if (!utils::context.global_rank) {
+    if (!utils::context().global_rank) {
       h5pp::archive res(results_file, "w");
       res.set_attribute("__grids_version__", dyson_solver.get_grids_version());
       res["G_tau_hs/data"] << g_tau_hs.object();
@@ -183,17 +183,17 @@ namespace green::mbpt {
       res["Sk_hs"] << Sk_hs;
       res.close();
     }
-    MPI_Barrier(utils::context.global);
+    MPI_Barrier(utils::context().global);
   }
 
   inline void sc_job(sc::sc_loop<shared_mem_dyson>& sc, const params::params& p, scf_type type, shared_mem_dyson& dyson,
                      utils::shared_object<ztensor<5>>& G_tau, utils::shared_object<ztensor<5>>& Sigma_tau, ztensor<4>& Sigma1) {
     read_hartree_fock_selfenergy(p, dyson.bz_utils(), Sigma1);
     G_tau.fence();
-    if (!utils::context.node_rank) G_tau.object().set_zero();
+    if (!utils::context().node_rank) G_tau.object().set_zero();
     G_tau.fence();
     Sigma_tau.fence();
-    if (!utils::context.node_rank) Sigma_tau.object().set_zero();
+    if (!utils::context().node_rank) Sigma_tau.object().set_zero();
     Sigma_tau.fence();
     // Hartree-Fock solver is used by all perturbation solvers.
     hf_solver hf(p, dyson.bz_utils(), dyson.S_k());
@@ -230,7 +230,7 @@ namespace green::mbpt {
                                     "Please verify the path is correct, or run the 'SC' job before running 'WINTER'.");
     }
     if (input.has_group("high_symm_path")) {
-      if (!utils::context.global_rank) std::cout << "Running Wannier interpolation" << std::endl;
+      if (!utils::context().global_rank) std::cout << "Running Wannier interpolation" << std::endl;
       sc::read_results(dyson.mu(), g0_tau, sigma1, sigma_tau, results_file);
       wannier_interpolation(dyson, sigma1, sigma_tau, input, p["high_symmetry_output_file"]);
     }
@@ -268,9 +268,9 @@ namespace green::mbpt {
       } else if (job == WINTER) {
         winter_job(sc, p, dyson, G_tau, Sigma_tau, Sigma1);
       }
-      if (!utils::context.global_rank) std::cout << "Job " << magic_enum::enum_name(job) << " is finished." << std::endl;
+      if (!utils::context().global_rank) std::cout << "Job " << magic_enum::enum_name(job) << " is finished." << std::endl;
     }
-    if (!utils::context.global_rank) std::cout << "Completed." << std::endl;
+    if (!utils::context().global_rank) std::cout << "Completed." << std::endl;
   }
 
 }  // namespace green::mbpt

--- a/src/gw_cpu_kernel.cpp
+++ b/src/gw_cpu_kernel.cpp
@@ -42,7 +42,7 @@ namespace green::mbpt::kernels {
     sigma_tau.fence();
     statistics.start("total");
     statistics.start("Main loop");
-    for (size_t q = utils::context.internode_rank; q < _inq; q += utils::context.internode_size) {
+    for (size_t q = utils::context().internode_rank; q < _inq; q += utils::context().internode_size) {
       size_t q_ir = _bz_utils.q_symmetry().full_point(q); // irreducible q-point's index in the full BZ
       selfenergy_innerloop(q_ir, g, sigma_tau, P0_tilde_s, Pw_tilde_s);
     }
@@ -289,7 +289,7 @@ namespace green::mbpt::kernels {
     _ft.w_b_to_tau_f(P0_w, P0_tilde.object(), t_offset, nt_local, true);
     //P0_tilde.fence();
     // for G0W0 correction
-    if (_q0_utils.q0_treatment() == extrapolate and utils::context.node_rank == 0) {
+    if (_q0_utils.q0_treatment() == extrapolate and utils::context().node_rank == 0) {
       size_t iq = _bz_utils.q_symmetry().reduced_point(q_ir);
       _q0_utils.aux_to_PW_00(P0_w, _eps_inv_wq, iq);
     }

--- a/src/hf_cpu_kernels.cpp
+++ b/src/hf_cpu_kernels.cpp
@@ -44,7 +44,7 @@ namespace green::mbpt::kernels {
       if(NQ_local > 0) {
         // TODO: We can save a lot of time here by reducing the loop over ikp, but that would require removing the NQ_local, NQ_offset framework.
         //        The symmetry speedup only works if we load all of NQ at once -- which shold be doable now that we have much smaller memory footprint.
-        for (int ikps = utils::context.internode_rank; ikps < _nk * _ns; ikps += utils::context.internode_size) {
+        for (int ikps = utils::context().internode_rank; ikps < _nk * _ns; ikps += utils::context().internode_size) {
           int is    = ikps % _ns;
           int ikp   = ikps / _ns;
           statistics.start("Read Coulomb Up");
@@ -64,7 +64,7 @@ namespace green::mbpt::kernels {
 
       upper_Coul /= double(_nk);
       if (NQ_local > 0) {
-        for (int ii = utils::context.internode_rank; ii < _ink * _ns; ii += utils::context.internode_size) {
+        for (int ii = utils::context().internode_rank; ii < _ink * _ns; ii += utils::context().internode_size) {
           int is   = ii / _ink;
           int ik   = ii % _ink;
           int k_ir = _bz_utils.k_symmetry().full_point(ik);
@@ -98,7 +98,7 @@ namespace green::mbpt::kernels {
       double     prefactor = (_ns == 2) ? 1.0 : 0.5;
       statistics.start("Exchange");
       if (NQ_local > 0) {
-        for (int ii = utils::context.internode_rank; ii < _ink * _ns; ii += utils::context.internode_size) {
+        for (int ii = utils::context().internode_rank; ii < _ink * _ns; ii += utils::context().internode_size) {
           int        is   = ii / _ink;
           int        ik   = ii % _ink;
           int        k_ir = _bz_utils.k_symmetry().full_point(ik);
@@ -183,7 +183,7 @@ namespace green::mbpt::kernels {
         ztensor<2> upper_Coul(_NQ, 1);
         upper_Coul.set_zero();
         MMatrixXcd upper_Coul_m(upper_Coul.data() + NQ_offset, NQ_local, 1);
-        for (int ikp = utils::context.internode_rank; ikp < _nk; ikp += utils::context.internode_size) {
+        for (int ikp = utils::context().internode_rank; ikp < _nk; ikp += utils::context().internode_size) {
           coul_int1.read_integrals(ikp, ikp);
           if(NQ_local > 0) {
             coul_int1.symmetrize(v, ikp, ikp, NQ_offset, NQ_local);
@@ -205,7 +205,7 @@ namespace green::mbpt::kernels {
 
         MatrixXcd  Fm(1, _nao * _nao);
         MMatrixXcd Fmm(Fm.data(), _nao, _nao);
-        for (int ik = utils::context.internode_rank; ik < _ink; ik += utils::context.internode_size) {
+        for (int ik = utils::context().internode_rank; ik < _ink; ik += utils::context().internode_size) {
           int k_ir = _bz_utils.k_symmetry().full_point(ik);
 
           coul_int1.read_integrals(k_ir, k_ir);

--- a/src/seet_solver.cpp
+++ b/src/seet_solver.cpp
@@ -74,15 +74,15 @@ namespace green::embedding {
     // (sigma_imp - DC) summed over impurities, ready to be added to the weak-coupling sigma.
     ztensor<3> sigma_inf_imp_loc(sigma_inf_weak_loc.shape());
     ztensor<4> sigma_tau_imp_loc(sigma_loc.shape());
-    if (!utils::context.global_rank) {
+    if (!utils::context().global_rank) {
       auto [sigma_inf_imp_, sigma_tau_imp_] = _solver.solve(_mu, ovlp_loc, h_core_loc,
                                                             sigma_inf_weak_loc, sigma_inf_full_loc,
                                                             sigma_loc, g_loc);
       sigma_inf_imp_loc << sigma_inf_imp_;
       sigma_tau_imp_loc << sigma_tau_imp_;
     }
-    MPI_Bcast(sigma_inf_imp_loc.data(), sigma_inf_imp_loc.size(), MPI_CXX_DOUBLE_COMPLEX, 0, utils::context.global);
-    MPI_Bcast(sigma_tau_imp_loc.data(), sigma_tau_imp_loc.size(), MPI_CXX_DOUBLE_COMPLEX, 0, utils::context.global);
+    MPI_Bcast(sigma_inf_imp_loc.data(), sigma_inf_imp_loc.size(), MPI_CXX_DOUBLE_COMPLEX, 0, utils::context().global);
+    MPI_Bcast(sigma_tau_imp_loc.data(), sigma_tau_imp_loc.size(), MPI_CXX_DOUBLE_COMPLEX, 0, utils::context().global);
 
     // Add impurity correction on top of the weak-coupling sigma (already in sigma_inf / sigma_tau).
     for (size_t is = 0; is < g.object().shape()[1]; ++is) {
@@ -91,7 +91,7 @@ namespace green::embedding {
         auto x_k_m = mbpt::matrix(x_k(ik));
         mbpt::matrix(sigma_inf(is, ik)) += x_k_m * mbpt::matrix(sigma_inf_imp_loc(is)) * x_k_m.adjoint();
         sigma_tau.fence();
-        for (size_t it = utils::context.node_rank; it < g.object().shape()[0]; it += utils::context.node_size) {
+        for (size_t it = utils::context().node_rank; it < g.object().shape()[0]; it += utils::context().node_size) {
           mbpt::matrix(sigma_tau.object()(it, is, ik)) += x_k_m * mbpt::matrix(sigma_tau_imp_loc(it, is)) * x_k_m.adjoint();
         }
         sigma_tau.fence();
@@ -103,7 +103,7 @@ namespace green::embedding {
     h5pp::archive ar(_weak_results_file, "r");
     ar[_base_path + "/Sigma1"] >> sigma_inf;
     sigma_tau.fence();
-    if (!utils::context.node_rank) {
+    if (!utils::context().node_rank) {
       ar[_base_path + "/Selfenergy/data"] >> sigma_tau.object();
     }
     sigma_tau.fence();

--- a/test/solvers_test.cpp
+++ b/test/solvers_test.cpp
@@ -409,7 +409,7 @@ TEST_CASE("SEET DC TEST") {
 }
 
 TEST_CASE("Context TEST") {
-  if(green::utils::mpi_context::context.global_rank > 1) {
+  if(green::utils::mpi_context::context().global_rank > 1) {
     return;
   }
   green::utils::mpi_context cntx(MPI_COMM_SELF);

--- a/test/solvers_test.cpp
+++ b/test/solvers_test.cpp
@@ -66,7 +66,7 @@ void solve_hf(const std::string& input, const std::string& int_hf, const std::st
   {
     green::h5pp::archive ar(test_file, "r");
     G_shared.fence();
-    if (!green::utils::context.node_rank) ar["G_tau"] >> G_shared.object();
+    if (!green::utils::context().node_rank) ar["G_tau"] >> G_shared.object();
     G_shared.fence();
     ar["result/Sigma1"] >> Sigma1_test;
     ar.close();
@@ -121,10 +121,10 @@ void solve_gw(const std::string& input, const std::string& int_f, const std::str
   {
     green::h5pp::archive ar(test_file, "r");
     G_shared.fence();
-    if (!green::utils::context.node_rank) ar["G_tau"] >> G_shared.object();
+    if (!green::utils::context().node_rank) ar["G_tau"] >> G_shared.object();
     G_shared.fence();
     S_shared_tst.fence();
-    if (!green::utils::context.node_rank) ar["result/Sigma_tau"] >> S_shared_tst.object();
+    if (!green::utils::context().node_rank) ar["result/Sigma_tau"] >> S_shared_tst.object();
     S_shared_tst.fence();
     ar.close();
   }
@@ -175,10 +175,10 @@ void solve_gf2(const std::string& df_int_path, const std::string& test_file, con
   {
     green::h5pp::archive ar(test_file, "r");
     G_shared.fence();
-    if (!green::utils::context.node_rank) ar["G_tau"] >> G_shared.object();
+    if (!green::utils::context().node_rank) ar["G_tau"] >> G_shared.object();
     G_shared.fence();
     S_shared_tst.fence();
-    if (!green::utils::context.node_rank) ar["result/Sigma_tau"] >> S_shared_tst.object();
+    if (!green::utils::context().node_rank) ar["result/Sigma_tau"] >> S_shared_tst.object();
     S_shared_tst.fence();
     ar.close();
   }
@@ -282,7 +282,7 @@ TEST_CASE("MBPT Solver") {
     auto S_shared = green::utils::shared_object(green::sc::ztensor<5>(nullptr, nts, ns, ink, nao, nao));
     auto Sigma1   = green::sc::ztensor<4>(ns, ink, nao, nao);
     S_shared.fence();
-    if (!green::utils::context.node_rank) S_shared.object().set_zero();
+    if (!green::utils::context().node_rank) S_shared.object().set_zero();
     S_shared.fence();
     Sigma1(0) << sc.dyson_solver().bz_utils().full_to_ibz(tmp(0));
     Sigma1(1) << sc.dyson_solver().bz_utils().full_to_ibz(tmp(1));


### PR DESCRIPTION
Update all `utils::context.` call sites to `utils::context().` following the replacement of the `context` preprocessor macro in green-utils with an inline function. Depends on Green-Phys/green-utils#5, Green-Phys/green-opt#8 and Green-Phys/green-sc#12

Also adds a workflow for testing MBPT code on MacOS systems (not sure if it will be fast enough to complete testing in time).