### PR TITLE
Remove redundant mpi_context parameter from HF solver interface

### DIFF
--- a/src/green/mbpt/hf_solver.h
+++ b/src/green/mbpt/hf_solver.h
@@ -21,7 +21,7 @@ namespace green::mbpt {
 
   class hf_solver {
     using bz_utils_t = symmetry::brillouin_zone_utils;
-    using callback_t = std::function<ztensor<4>(const ztensor<4>&, const utils::mpi_context&)>;
+    using callback_t = std::function<ztensor<4>(const ztensor<4>&)>;
 
   public:
     hf_solver(const params::params& p, const bz_utils_t& bz_utils, const ztensor<4>& S_k) {

--- a/src/green/mbpt/kernel_factory.h
+++ b/src/green/mbpt/kernel_factory.h
@@ -42,7 +42,7 @@ namespace green::mbpt::kernels {
     using x_type     = ztensor<4>;
 
   public:
-    static std::tuple<std::shared_ptr<void>, std::function<x_type(const x_type&, const utils::mpi_context&)>> get_kernel(bool X2C, const params::params& p,
+    static std::tuple<std::shared_ptr<void>, std::function<x_type(const x_type&)>> get_kernel(bool X2C, const params::params& p,
                                                                                               size_t nao, size_t nso, size_t ns,
                                                                                               size_t NQ, double madelung,
                                                                                               const bz_utils_t& bz_utils,
@@ -50,14 +50,14 @@ namespace green::mbpt::kernels {
       if (p["kernel"].as<kernel_type>() == CPU) {
         if (X2C) {
           std::shared_ptr<void> kernel(new hf_x2c_cpu_kernel(p, nao, nso, ns, NQ, madelung, bz_utils, S_k));
-          std::function         callback = [kernel](const x_type& dm, const utils::mpi_context& ctx) -> x_type {
-            return static_cast<hf_x2c_cpu_kernel*>(kernel.get())->solve(dm, ctx);
+          std::function         callback = [kernel](const x_type& dm) -> x_type {
+            return static_cast<hf_x2c_cpu_kernel*>(kernel.get())->solve(dm);
           };
           return std::tuple{kernel, callback};
         }
         std::shared_ptr<void> kernel(new hf_scalar_cpu_kernel(p, nao, nso, ns, NQ, madelung, bz_utils, S_k));
-        std::function         callback = [kernel](const x_type& dm, const utils::mpi_context& ctx) -> x_type {
-          return static_cast<hf_scalar_cpu_kernel*>(kernel.get())->solve(dm, ctx);
+        std::function         callback = [kernel](const x_type& dm) -> x_type {
+          return static_cast<hf_scalar_cpu_kernel*>(kernel.get())->solve(dm);
         };
         return std::tuple{kernel, callback};
       }

--- a/src/green/mbpt/kernels.h
+++ b/src/green/mbpt/kernels.h
@@ -224,7 +224,7 @@ namespace green::mbpt::kernels {
     hf_scalar_cpu_kernel(const params::params& p, size_t nao, size_t nso, size_t ns, size_t NQ, double madelung,
                          const bz_utils_t& bz_utils, const ztensor<4>& S_k) :
         hf_kernel(p, nao, nso, ns, NQ, madelung, bz_utils, S_k) {}
-    S1_type solve(const dm_type& dm, const utils::mpi_context& ctx = utils::mpi_context::context());
+    S1_type solve(const dm_type& dm);
   };
 
   class hf_x2c_cpu_kernel : public hf_kernel {
@@ -232,7 +232,7 @@ namespace green::mbpt::kernels {
     hf_x2c_cpu_kernel(const params::params& p, size_t nao, size_t nso, size_t ns, size_t NQ, double madelung,
                       const bz_utils_t& bz_utils, const ztensor<4>& S_k) :
         hf_kernel(p, nao, nso, ns, NQ, madelung, bz_utils, S_k) {}
-    S1_type solve(const dm_type& dm, const utils::mpi_context& ctx = utils::mpi_context::context());
+    S1_type solve(const dm_type& dm);
 
   private:
     MatrixXcd compute_exchange(int ik, ztensor<3>& dm_s1_s2, ztensor<3>& dm_ms1_ms2, ztensor<3>& v, df_integral_t& coul_int1,

--- a/src/hf_cpu_kernels.cpp
+++ b/src/hf_cpu_kernels.cpp
@@ -22,16 +22,16 @@
 #include "green/mbpt/kernels.h"
 
 namespace green::mbpt::kernels {
-  ztensor<4> hf_scalar_cpu_kernel::solve(const ztensor<4>& dm, const utils::mpi_context& ctx) {
+  ztensor<4> hf_scalar_cpu_kernel::solve(const ztensor<4>& dm) {
     statistics.start("Hartree-Fock");
     ztensor<4> new_Fock(_ns, _ink, _nao, _nao);
     new_Fock.set_zero();
     {
-      df_integral_t coul_int1(_hf_path, _nao, _NQ, _bz_utils, ctx);
-      size_t        NQ_local = _NQ / ctx.node_size;
-      NQ_local += (_NQ % ctx.node_size > ctx.node_rank) ? 1 : 0;
-      size_t NQ_offset = NQ_local * ctx.node_rank +
-                         ((_NQ % ctx.node_size > ctx.node_rank) ? 0 : (_NQ % ctx.node_size));
+      df_integral_t coul_int1(_hf_path, _nao, _NQ, _bz_utils);
+      size_t        NQ_local = _NQ / utils::context().node_size;
+      NQ_local += (_NQ % utils::context().node_size > utils::context().node_rank) ? 1 : 0;
+      size_t NQ_offset = NQ_local * utils::context().node_rank +
+                         ((_NQ % utils::context().node_size > utils::context().node_rank) ? 0 : (_NQ % utils::context().node_size));
       NQ_offset = (NQ_offset >= _NQ) ? 0 : NQ_offset;
       statistics.start("Direct");
       // Direct diagram
@@ -59,7 +59,7 @@ namespace green::mbpt::kernels {
         }
       }
       statistics.start("Reduce Direct");
-      MPI_Allreduce(MPI_IN_PLACE, upper_Coul.data(), upper_Coul.size(), MPI_CXX_DOUBLE_COMPLEX, MPI_SUM, ctx.global);
+      MPI_Allreduce(MPI_IN_PLACE, upper_Coul.data(), upper_Coul.size(), MPI_CXX_DOUBLE_COMPLEX, MPI_SUM, utils::context().global);
       statistics.end();
 
       upper_Coul /= double(_nk);
@@ -126,7 +126,7 @@ namespace green::mbpt::kernels {
       statistics.end();
 
       statistics.start("Ewald correction");
-      for (int ii = ctx.global_rank; ii < _ns * _ink; ii += ctx.global_size) {
+      for (int ii = utils::context().global_rank; ii < _ns * _ink; ii += utils::context().global_size) {
         int         is = ii / _ink;
         int         ik = ii % _ink;
         CMMatrixXcd dmm(dm.data() + is * _ink * _nao * _nao + ik * _nao * _nao, _nao, _nao);
@@ -137,19 +137,19 @@ namespace green::mbpt::kernels {
       statistics.end();
     }
     statistics.start("Reduce Fock");
-    utils::allreduce(MPI_IN_PLACE, new_Fock.data(), new_Fock.size(), MPI_C_DOUBLE_COMPLEX, MPI_SUM, ctx.global);
+    utils::allreduce(MPI_IN_PLACE, new_Fock.data(), new_Fock.size(), MPI_C_DOUBLE_COMPLEX, MPI_SUM, utils::context().global);
     statistics.end();
     statistics.end();
-    statistics.print(ctx.global);
+    statistics.print(utils::context().global);
     return new_Fock;
   }
 
-  ztensor<4> hf_x2c_cpu_kernel::solve(const ztensor<4>& dm, const utils::mpi_context& ctx) {
+  ztensor<4> hf_x2c_cpu_kernel::solve(const ztensor<4>& dm) {
     statistics.start("X2C Hartree-Fock");
     ztensor<4> new_Fock(1, _ink, _nso, _nso);
     new_Fock.set_zero();
     {
-      df_integral_t coul_int1(_hf_path, _nao, _NQ, _bz_utils, ctx);
+      df_integral_t coul_int1(_hf_path, _nao, _NQ, _bz_utils);
 
       ztensor<3>    dm_spblks[3]{
           {_ink, _nao, _nao},
@@ -166,10 +166,10 @@ namespace green::mbpt::kernels {
         matrix(dm_spblks[2](ik)) = dmm.block(0, _nao, _nao, _nao);
       }
 
-      size_t NQ_local = _NQ / ctx.node_size;
-      NQ_local += (_NQ % ctx.node_size > ctx.node_rank) ? 1 : 0;
-      size_t NQ_offset = NQ_local * ctx.node_rank +
-                         ((_NQ % ctx.node_size > ctx.node_rank) ? 0 : (_NQ % ctx.node_size));
+      size_t NQ_local = _NQ / utils::context().node_size;
+      NQ_local += (_NQ % utils::context().node_size > utils::context().node_rank) ? 1 : 0;
+      size_t NQ_offset = NQ_local * utils::context().node_rank +
+                         ((_NQ % utils::context().node_size > utils::context().node_rank) ? 0 : (_NQ % utils::context().node_size));
       NQ_offset = (NQ_offset >= _NQ) ? 0 : NQ_offset;
       ztensor<3> v(NQ_local, _nao, _nao);
       // Direct diagram
@@ -199,7 +199,7 @@ namespace green::mbpt::kernels {
           }
         }
         statistics.start("Reduce Direct");
-        MPI_Allreduce(MPI_IN_PLACE, upper_Coul.data(), upper_Coul.size(), MPI_CXX_DOUBLE_COMPLEX, MPI_SUM, ctx.global);
+        MPI_Allreduce(MPI_IN_PLACE, upper_Coul.data(), upper_Coul.size(), MPI_CXX_DOUBLE_COMPLEX, MPI_SUM, utils::context().global);
         statistics.end();
         upper_Coul /= double(_nk);
 
@@ -238,7 +238,7 @@ namespace green::mbpt::kernels {
       MMatrixXcd v2m(v2.data(), _nao, NQ_local * _nao);
       MMatrixXcd v2mm(v2.data(), _nao * NQ_local, _nao);
 
-      for (int iks = ctx.internode_rank; iks < 3 * _ink; iks += ctx.internode_size) {
+      for (int iks = utils::context().internode_rank; iks < 3 * _ink; iks += utils::context().internode_size) {
         size_t      ik = iks / 3;
         size_t      is = iks % 3;
         MMatrixXcd  Fm_nso(new_Fock.data() + ik * _nso * _nso, _nso, _nso);
@@ -268,10 +268,10 @@ namespace green::mbpt::kernels {
     }
 
     statistics.start("Reduce Fock");
-    utils::allreduce(MPI_IN_PLACE, new_Fock.data(), new_Fock.size(), MPI_C_DOUBLE_COMPLEX, MPI_SUM, ctx.global);
+    utils::allreduce(MPI_IN_PLACE, new_Fock.data(), new_Fock.size(), MPI_C_DOUBLE_COMPLEX, MPI_SUM, utils::context().global);
     statistics.end();
     statistics.end();
-    statistics.print(ctx.global);
+    statistics.print(utils::context().global);
     return new_Fock;
   }
 

--- a/src/hf_solver.cpp
+++ b/src/hf_solver.cpp
@@ -12,6 +12,6 @@ namespace green::mbpt {
     ztensor<4> dm(shape);
     dm << g.object()(g.object().shape()[0] - 1);
     dm *= _spin_prefactor;
-    sigma1 << _callback(dm, g.cntx());
+    sigma1 << _callback(dm);
   }
 }  // namespace green::mbpt


### PR DESCRIPTION
## Summary                                                                                                                                                                                                      
                                                                                                                                                                                                                
- `mpi_context` argument added to `hf_solver::callback_t`, `hf_kernel_factory::get_kernel`, and both `hf_*_cpu_kernel::solve` methods was redundant — every use was equivalent to `utils::context()`, the global MPI singleton
- No code path (including the embedding/SEET solver) ever supplies a non-global context: `shared_object` always initialises with the global default, so `g.cntx()` in `hf_solver.cpp` was identical to `utils::context()`
- The change was introduced in WIP commit 8460ef2 during the SEET merge and broke API compatibility with external kernels (e.g. `green-gpu`) that expect the original callback signature `std::function<ztensor<4>(const ztensor<4>&)>`


## Changes                                                                                                                                                                                                    

Drops `mpi_context` from `callback_t`, `get_kernel` return type and lambdas, and both `solve` signatures. All `ctx.*` accesses in `hf_cpu_kernels.cpp` replaced with `utils::context().*`, making the file fully consistent (several lines already used the global directly).