### PR TITLE
Update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/green_tag.yaml
+++ b/.github/workflows/green_tag.yaml
@@ -58,7 +58,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           ref: main  # important: checkout main, not the tag
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: self-hosted
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
       - name: Build
         run: |
@@ -55,7 +55,7 @@ jobs:
           lcov --list coverage.info
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           flags: unittests
         env:

--- a/.github/workflows/test_macos.yaml
+++ b/.github/workflows/test_macos.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` from `v4` → `v4.2.2` in all three workflows (`test.yaml`, `test_macos.yaml`, `green_tag.yaml`)
- Bump `codecov/codecov-action` from `v3` → `v5` in `test.yaml`

These changes address the deprecation warning:
> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## Test plan
- [ ] CI passes on `test.yaml` (self-hosted Linux runner)
- [ ] CI passes on `test_macos.yaml` (macOS runner)
- [ ] No Node.js 20 deprecation warnings in CI output

🤖 Generated with [Claude Code](https://claude.com/claude-code)