### PR TITLE
fix(inchworm): don't double-count mu when extracting self-energy

### DIFF
--- a/python/inchworm_utils.py
+++ b/python/inchworm_utils.py
@@ -225,7 +225,7 @@ def interpolation(tau_grid_in, X_tau, tau_grid_new, kind="cubic"):
     return new_delta_tau
 
 
-def get_inchworm_selfenergy(green_path, time_file, hopping_file, delta_file, nao_imp, ir_file, beta, mu, uhf=True):
+def get_inchworm_selfenergy(green_path, time_file, hopping_file, delta_file, nao_imp, ir_file, beta, uhf=True):
     """Extract static and dynamic self-energies on IR grid from, e.g., Inchworm data
 
     Parameters
@@ -244,8 +244,6 @@ def get_inchworm_selfenergy(green_path, time_file, hopping_file, delta_file, nao
         Path to IR file
     beta : float
         Inverse temperature
-    mu : float
-        Chemical potential
     uhf : bool, optional
         Whether the data is for unrestricted Hartree-Fock, by default True
 
@@ -272,11 +270,18 @@ def get_inchworm_selfenergy(green_path, time_file, hopping_file, delta_file, nao
     green_omega_IR = myir.tau_to_w(green_tau_IR)
 
     # Compute self-energy in Matsubara frequency
+    #
+    # The hopping matrix written by inchworm_impurity_solver already has
+    # the chemical potential baked in:
+    #     H0_imp = h_core_eff + Sigma_dc_inf - mu * S
+    # (see green-impurity/src/inchworm_impurity_solver.cpp). Therefore
+    # g0_inv must be built as (iw)*I - H0_imp - Delta(iw); adding mu
+    # explicitly here would double-count it.
     ns = 2 if uhf else 1
     sigma_omega_IR = np.zeros_like(green_omega_IR, dtype=complex)
     for s in range(ns):
         for iw, w_val in enumerate(myir.wsample):
-            g0_inv = (1j * w_val + mu) * np.eye(nao_imp, dtype=complex) - hopping[s] - delta_omega_IR[iw, s]
+            g0_inv = (1j * w_val) * np.eye(nao_imp, dtype=complex) - hopping[s] - delta_omega_IR[iw, s]
             g_inv = LA.inv(green_omega_IR[iw, s])
             sigma_omega_IR[iw, s] = g0_inv - g_inv
 

--- a/python/submit_seet_inchworm_loop.py
+++ b/python/submit_seet_inchworm_loop.py
@@ -228,7 +228,7 @@ def process_inchworm_output(iteration: int, workdir: Path, args: argparse.Namesp
         # NOTE: Replace `get_inchworm_selfenergy` with a custom defined function for other applications
         sigma_inf, sigma_tau = get_inchworm_selfenergy(
             default_green_func_path, default_time_filename, f'imp_{i}_hopping.txt', f'imp_{i}_delta.txt',
-            nao_imp[i], args.ir_file, args.BETA, mu, args.uhf
+            nao_imp[i], args.ir_file, args.BETA, args.uhf
         )
         sigma_inf_inchworm.append(sigma_inf)
         sigma_tau_inchworm.append(sigma_tau)


### PR DESCRIPTION
## Summary

`green-impurity/src/inchworm_impurity_solver.cpp:40` writes the impurity hopping matrix with the chemical potential baked in:

```cpp
auto h_imp = hcore_eff(s1, i, j) + delta_1(s1, i, j) - mu * ovlp(s1, i, j);
```

i.e. `H0_imp = h_core_eff + Σ∞ − μ·S` is what shows up in `imp_*_hopping.txt`.

`get_inchworm_selfenergy` in `python/inchworm_utils.py` was then building `g0_inv` as

```python
(1j * w_val + mu) * I - hopping[s] - delta_omega_IR[iw, s]
```

which after substitution gives `(iw + 2μ)·I − h_core_eff − Σ∞ − Δ(iw)` — `μ` is double-counted. With S = I in the impurity basis, the correct form is

```
g0_inv = iw·I − hopping[s] − Δ(iw)
```

since the chemical potential is already inside `hopping`.

## Changes

- `inchworm_utils.py::get_inchworm_selfenergy`: drop `+ mu` from the `g0_inv` expression; drop the now-unused `mu` parameter; add a comment pointing at the impurity-solver source explaining the convention.
- `submit_seet_inchworm_loop.py`: update the one caller to match the new signature (no `mu` argument).

## Test plan

No automated test in this codebase covers `get_inchworm_selfenergy` end-to-end. Reviewed by inspection against `inchworm_impurity_solver.cpp:40`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)